### PR TITLE
Replace RCurl with httr to provide support to TLS 1.2

### DIFF
--- a/R/graphRequest.R
+++ b/R/graphRequest.R
@@ -21,19 +21,25 @@ graphRequest <- function(
 ){
    customrequest <- match.arg(customrequest)
    postfields <- jsonlite::toJSON(postText, auto_unbox = T)
-   tg = RCurl::basicTextGatherer()
-   hg = RCurl::basicHeaderGatherer()
-   RCurl::curlPerform(
-      url = paste0(graph$url, endpoint),
-      httpheader=graph$headers,
-      customrequest = customrequest,
-      writefunction = tg$update,
-      headerfunction = hg$update,
-      postfields=postfields,
-      .encoding="UTF-8"
-   )
+
+   if (customrequest== "GET")
+   {
+       res <- GET(url = paste0(graph$url, endpoint),
+                 config=graph$headers,
+                 body = postfields)
+   }
+   else if (customrequest== "POST")
+   {
+      res <- POST(url = paste0(graph$url, endpoint),
+                 config=graph$headers,
+                 body = postfields)
+   }
+   
+   res.content = httr::content(res, as='text', encoding='UTF-8')
+   
    invisible(list(
-      header=hg$value(),
-      result=jsonlite::fromJSON(tg$value(), simplifyVector=FALSE)
+      header=headers(res),
+      status_code=status_code(res),
+      result=jsonlite::fromJSON(res.content, simplifyVector=FALSE)
    ))
 }

--- a/R/startGraph.R
+++ b/R/startGraph.R
@@ -35,7 +35,7 @@ startGraph <- function(
       sub("[/]db.*$", "", url)
    )
    ## Set general header ----
-   neo4jHeaders <- list(
+   neo4jHeaders <- httr::add_headers(
       'Accept' = 'application/json; charset=UTF-8;',
       'Content-Type' = 'application/json',
       'X-Stream' = TRUE,
@@ -53,8 +53,9 @@ startGraph <- function(
    )
    ## Find neo4j version and database name ----
    conStatus <- graphRequest(toRet, "", "GET", "")
-   if(is.na(conStatus$header["status"]) || conStatus$header["status"]!="200"){
+   if(conStatus$status_code !="200"){
       print(conStatus$header)
+      print(conStatus$status_code)
       stop("Cannot connect to the Neo4j database")
    }
    if("neo4j_version" %in% names(conStatus$result)){
@@ -66,10 +67,9 @@ startGraph <- function(
          database <- "data"
       }
       conStatus <- graphRequest(toRet, sprintf("/db/%s/", database), "GET", "")
-      if(
-         is.na(conStatus$header["status"]) || conStatus$header["status"]!="200"
-      ){
+      if(conStatus$status_code !="200"){
          print(conStatus$header)
+         print(conStatus$status_code)
          stop("Cannot connect to the Neo4j database")
       }
       if("neo4j_version" %in% names(conStatus$result)){


### PR DESCRIPTION
Current RCurl only supports TLS 1.0 which is not acceptable to current security standard. Replacing RCurl with httr will enable Neo2R to support TLS 1.2